### PR TITLE
Use OES_vertex_array_object

### DIFF
--- a/webgl-dynamicdraw.js
+++ b/webgl-dynamicdraw.js
@@ -58,7 +58,7 @@ WebGLDynamicDraw.DynamicDrawContext.prototype = {
 	recordArray: null,
 	drawBuffer: null,
 	
-	vertexArrayOES: 0,
+	vertexArrayOES: null,
 	
 	maxVertexAttribs: -1,
 	vertexAttribs: [],
@@ -87,7 +87,7 @@ WebGLDynamicDraw.DynamicDrawContext.prototype = {
 		cgl.bufferData(cgl.ARRAY_BUFFER, this.recordArray.array, cgl.STREAM_DRAW);
 		
 		// setup vertexattribs
-		if(this.vertexArrayOES != 0) {
+		if(this.vertexArrayOES) {
 			this.OESVertexArrayObject.bindVertexArrayOES(this.vertexArrayOES);
 			
 			for(var i = 0; i < this.vertexAttribs.length; i++) {
@@ -127,8 +127,8 @@ WebGLDynamicDraw.DynamicDrawContext.prototype = {
 		cgl.drawArrays(this.currentPrimitiveMode, 0, primitivesToDraw);
 		
 		// unbind vertexarray
-		if(this.vertexArrayOES != 0) {
-			this.OESVertexArrayObject.bindVertexArrayOES(0);
+		if(this.vertexArrayOES) {
+			this.OESVertexArrayObject.bindVertexArrayOES(null);
 		}
 	},
 	

--- a/webgl-dynamicdraw.js
+++ b/webgl-dynamicdraw.js
@@ -49,6 +49,7 @@ WebGLDynamicDraw.DynamicDrawContext = function(gl) {
 	
 	// DEBUG: log
 	console.debug("created DynamicDrawContext:", this);
+	console.debug("support OES_vertex_array_object=" + (this.OESVertexArrayObject !== null));
 };
 WebGLDynamicDraw.DynamicDrawContext.prototype = {
 	gl: null,

--- a/webgl-dynamicdraw.js
+++ b/webgl-dynamicdraw.js
@@ -86,15 +86,37 @@ WebGLDynamicDraw.DynamicDrawContext.prototype = {
 		cgl.bufferData(cgl.ARRAY_BUFFER, this.recordArray.array, cgl.STREAM_DRAW);
 		
 		// setup vertexattribs
-		for(var i = 0; i < this.vertexAttribs.length; i++) {
-			var attrib = this.vertexAttribs[i];
+		if(this.vertexArrayOES != 0) {
+			this.OESVertexArrayObject.bindVertexArrayOES(this.vertexArrayOES);
 			
-			if(attrib.enabled) {
-				cgl.enableVertexAttribArray(i);
-				cgl.vertexAttribPointer(i, attrib.size, attrib.type, attrib.normalized, this.recordArray.tempVertexIndexStride*4, this.recordArray.tempAttribOffset[i]*4);
+			for(var i = 0; i < this.vertexAttribs.length; i++) {
+				var attrib = this.vertexAttribs[i];
+				
+				if(attrib.dirtyGL) {
+					if(attrib.enabled) {
+						cgl.enableVertexAttribArray(i);
+						cgl.vertexAttribPointer(i, attrib.size, attrib.type, attrib.normalized, this.recordArray.tempVertexIndexStride*4, this.recordArray.tempAttribOffset[i]*4);
+					}
+					else {
+						cgl.disableVertexAttribArray(i);
+					}
+					
+					// reset dirty flag
+					attrib.dirtyGL = false;
+				}
 			}
-			else {
-				cgl.disableVertexAttribArray(i);
+		}
+		else {
+			for(var i = 0; i < this.vertexAttribs.length; i++) {
+				var attrib = this.vertexAttribs[i];
+				
+				if(attrib.enabled) {
+					cgl.enableVertexAttribArray(i);
+					cgl.vertexAttribPointer(i, attrib.size, attrib.type, attrib.normalized, this.recordArray.tempVertexIndexStride*4, this.recordArray.tempAttribOffset[i]*4);
+				}
+				else {
+					cgl.disableVertexAttribArray(i);
+				}
 			}
 		}
 		
@@ -102,6 +124,11 @@ WebGLDynamicDraw.DynamicDrawContext.prototype = {
 		var primitivesToDraw = this.recordArray.position / this.recordArray.tempVertexIndexStride;
 		
 		cgl.drawArrays(this.currentPrimitiveMode, 0, primitivesToDraw);
+		
+		// unbind vertexarray
+		if(this.vertexArrayOES != 0) {
+			this.OESVertexArrayObject.bindVertexArrayOES(0);
+		}
 	},
 	
 	/** Adds a vertex with three components to the vertex attribute attrib */

--- a/webgl-dynamicdraw.js
+++ b/webgl-dynamicdraw.js
@@ -25,11 +25,17 @@ var WebGLDynamicDraw = {
 WebGLDynamicDraw.DynamicDrawContext = function(gl) {
 	this.gl = gl;
 	
+	// try create OES_vertex_array_object extension
+	this.OESVertexArrayObject = gl.getExtension("OES_vertex_array_object");
+	
 	// create recordArray
 	this.recordArray = new WebGLDynamicDraw.RecordArray(this, 256);
 	
 	// create drawBuffer
 	this.drawBuffer = new WebGLDynamicDraw.DrawBuffer(this, 256);
+	
+	// create vertexarray
+	this.vertexArrayOES = this.OESVertexArrayObject.createVertexArrayOES();
 	
 	// query max vertex attribs
 	this.maxVertexAttribs = this.gl.getParameter(this.gl.MAX_VERTEX_ATTRIBS);
@@ -46,8 +52,12 @@ WebGLDynamicDraw.DynamicDrawContext = function(gl) {
 };
 WebGLDynamicDraw.DynamicDrawContext.prototype = {
 	gl: null,
+	OESVertexArrayObject: null,
+	
 	recordArray: null,
 	drawBuffer: null,
+	
+	vertexArrayOES: 0,
 	
 	maxVertexAttribs: -1,
 	vertexAttribs: [],

--- a/webgl-dynamicdraw.js
+++ b/webgl-dynamicdraw.js
@@ -120,12 +120,14 @@ WebGLDynamicDraw.DynamicDrawContext.prototype = {
 		var attrib = this.vertexAttribs[index];
 		
 		attrib.update(size, type, normalized);
+		attrib.dirtyGL = true;
 	},
 	
 	enableVertexAttrib: function(index, enabled) {
 		var attrib = this.vertexAttribs[index];
 		
 		attrib.enabled = enabled;
+		attrib.dirtyGL = true;
 	},
 	
 	incrementingVertexAttrib: function(index) {
@@ -261,6 +263,8 @@ WebGLDynamicDraw.VertexAttrib.prototype = {
 	normalized: false,
 	
 	enabled: false,
+	
+	dirtyGL: false,
 	
 	update: function(size, type, normalized) {
 		this.size = size;


### PR DESCRIPTION
Implement vertexarrays from OES_vertex_array_object for better performance.

Without vertexarrays each draw in `end()` requires _all_ vertex attributes to be enabled/disabled and setup via `vertexAttribPointer`. With the default number of vertex attributes bein 16 that is quite the state change.